### PR TITLE
Fix NullPointerException when incorrect schema in database

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -1505,15 +1505,15 @@ public class GrailsDomainBinder implements MetadataContributor {
                 configureDerivedProperties(sub, subMapping);
             }
         }
-        Integer bs = m.getBatchSize();
+        Integer bs = (m == null) ? null : m.getBatchSize();
         if (bs != null) {
             subClass.setBatchSize(bs);
         }
 
-        if (m.getDynamicUpdate()) {
+        if (m != null && m.getDynamicUpdate()) {
             subClass.setDynamicUpdate(true);
         }
-        if (m.getDynamicInsert()) {
+        if (m != null && m.getDynamicInsert()) {
             subClass.setDynamicInsert(true);
         }
 


### PR DESCRIPTION
I can confirm same problem in this 8.1.x branch, when using application with Grails 6.2.3

This has been already merged in 7.2.x (https://github.com/grails/grails-data-hibernate5/pull/988) and 9.0.x branches.

